### PR TITLE
fix: remove SMB types in BaseViewer class

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,13 @@ Or for WHEP in a similar way https://webrtc.player.eyevinn.technology/?type=whep
 
 ## Support
 
-Join our [community on Slack](http://slack.streamingtech.se) where you can post any questions regarding any of our open source projects. If you fancy any help in enhancing or integrating this component just drop an email to sales@eyevinn.se and we'll figure something out together.
+Join our [community on Slack](http://slack.streamingtech.se) where you can post any questions regarding any of our open source projects. Eyevinn's consulting business can also offer you:
+
+- Further development of this component
+- Customization and integration of this component into your platform
+- Support and maintenance agreement
+
+Contact [sales@eyevinn.se](mailto:sales@eyevinn.se) if you are interested.
 
 ## About Eyevinn Technology
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ npm run dev
 
 If you don't have a WHIP stream you can go to https://web.whip.eyevinn.technology and enter this endpoint URL: [http://localhost:8200/api/v2/whip/sfu-broadcaster?channelId=test](https://web.whip.eyevinn.technology/?endpoint=http%3A%2F%2Flocalhost%3A8200%2Fapi%2Fv2%2Fwhip%2Fsfu-broadcaster%3FchannelId%3Dtest)
 
-To try playback with for example WHPP you can open a browser at https://webrtc.player.eyevinn.technology and enter `http://localhost:8001/whpp/channel/test` as WHPP url.
+To try playback with for example WHEP you can open a browser at https://webrtc.player.eyevinn.technology and enter `http://localhost:8001/whep/channel/test` as WHEP url.
 
 Or for WHEP in a similar way https://webrtc.player.eyevinn.technology/?type=whep and enter `http://localhost:8001/whep/channel/test` as WHEP url.
 

--- a/src/core/baseViewer.ts
+++ b/src/core/baseViewer.ts
@@ -2,10 +2,8 @@ import { v4 as uuidv4 } from "uuid";
 import { EventEmitter } from "events";
 import { SessionDescription } from "sdp-transform";
 
-import { SfuProtocol } from "./sfu/interface";
+import { SfuProtocol, SfuEndpointDescription } from "./sfu/interface";
 import { MediaStreamsInfo } from "./mediaStreamsInfo";
-import { Viewer } from "./interface";
-import { SmbEndpointDescription } from "./sfu/smb";
 
 export class BaseViewer extends EventEmitter {
   private resourceId: string;
@@ -15,7 +13,7 @@ export class BaseViewer extends EventEmitter {
   private usedMids: string[] = [];
 
   protected mediaStreams?: MediaStreamsInfo;
-  protected endpointDescription: SmbEndpointDescription;
+  protected endpointDescription: SfuEndpointDescription;
 
   constructor(channelId: string, resourceId: string, sfuProtocol: SfuProtocol, mediaStreams: MediaStreamsInfo) {
     super();

--- a/src/core/sfu/interface.ts
+++ b/src/core/sfu/interface.ts
@@ -2,11 +2,85 @@ export enum SfuType {
   smb = "SMB"
 }
 
+interface SfuCandidate {
+  'generation': number;
+  'component': number;
+  'protocol': string;
+  'port': number;
+  'ip': string;
+  'rel-port'?: number;
+  'rel-addr'?: string;
+  'foundation': string;
+  'priority': number;
+  'type': string;
+  'network'?: number;
+}
+
+export interface SfuTransport {
+  'rtcp-mux'?: boolean;
+
+  'ice'?: {
+    'ufrag': string;
+    'pwd': string;
+    'candidates': SfuCandidate[];
+  };
+  'dtls'?: {
+    'setup': string;
+    'type': string;
+    'hash': string;
+  };
+}
+
+interface RtcpFeedback {
+  'type': string;
+  'subtype': string;
+}
+
+interface SfuPayloadType {
+  'id': number;
+  'name': string;
+  'clockrate': number;
+  'channels'?: number;
+  'parameters'?: any;
+  'rtcp-fbs'?: RtcpFeedback[];
+}
+
+interface SfuRtpHeaderExtension {
+  'id': number;
+  'uri': string;
+}
+
+export interface SfuVideoSource {
+  'main': number;
+  'feedback'?: number;
+}
+
+export interface SfuVideoStream {
+  'sources': SfuVideoSource[];
+  'id': string;
+  'content': string;
+}
+
+export interface SfuEndpointDescription {
+  'bundle-transport'?: SfuTransport;
+  'audio'?: {
+    'ssrcs': number[];
+    'payload-type': SfuPayloadType;
+    'rtp-hdrexts': SfuRtpHeaderExtension[];
+  };
+
+  'video'?: {
+    'streams': SfuVideoStream[];
+    'payload-types': SfuPayloadType[];
+    'rtp-hdrexts'?: SfuRtpHeaderExtension[];
+  };
+}
+
 export interface SfuProtocol {
   log(...args: any[]);
   allocateEndpoint(conferenceId: string, 
-    endpointId: string, audio: boolean, video: boolean, data: boolean): Promise<any>;
+    endpointId: string, audio: boolean, video: boolean, data: boolean): Promise<SfuEndpointDescription>;
   configureEndpoint(conferenceId: string, endpointId: string, 
-    endpointDescription: any): Promise<void>;
+    endpointDescription: SfuEndpointDescription): Promise<void>;
 
 }

--- a/src/core/sfu/protocolFactory.ts
+++ b/src/core/sfu/protocolFactory.ts
@@ -1,11 +1,10 @@
 import { SfuType } from "./interface";
-import { SmbProtocol } from "./smb";
+import { SmbProtocol, SmbProtocolOptions } from "./smb";
 
 export default function (type: SfuType, sfuOptions) {
   switch (type) {
     case SfuType.smb:
-      return new SmbProtocol(sfuOptions);
-      break;
+      return new SmbProtocol(<SmbProtocolOptions>sfuOptions);
     default:
       throw new Error("Unsupported SFU type " + type);
   }

--- a/src/core/sfu/smb.ts
+++ b/src/core/sfu/smb.ts
@@ -1,83 +1,12 @@
 import fetch from 'node-fetch';
-import { SfuProtocol } from "./interface";
+import { SfuEndpointDescription, SfuProtocol, SfuTransport } from "./interface";
 
 export interface SmbProtocolOptions {
   smbUrl: string;
   smbApiKey?: string;
 }
 
-interface SmbCandidate {
-  'generation': number;
-  'component': number;
-  'protocol': string;
-  'port': number;
-  'ip': string;
-  'rel-port'?: number;
-  'rel-addr'?: string;
-  'foundation': string;
-  'priority': number;
-  'type': string;
-  'network'?: number;
-}
-
-interface SmbTransport {
-  'rtcp-mux'?: boolean;
-  'ice'?: {
-    'ufrag': string;
-    'pwd': string;
-    'candidates': SmbCandidate[];
-  };
-  'dtls'?: {
-    'setup': string;
-    'type': string;
-    'hash': string;
-  };
-}
-
-interface RtcpFeedback {
-  'type': string;
-  'subtype': string;
-}
-
-interface SmbPayloadType {
-  'id': number;
-  'name': string;
-  'clockrate': number;
-  'channels'?: number;
-  'parameters'?: any;
-  'rtcp-fbs'?: RtcpFeedback[];
-}
-
-interface SmbRtpHeaderExtension {
-  'id': number;
-  'uri': string;
-}
-
-export interface SmbVideoSource {
-  'main': number;
-  'feedback'?: number;
-}
-
-export interface SmbVideoStream {
-  'sources': SmbVideoSource[];
-  'id': string;
-  'content': string;
-}
-
-export interface SmbEndpointDescription {
-  'bundle-transport'?: SmbTransport;
-  'audio'?: {
-    'ssrcs': number[];
-    'payload-type': SmbPayloadType;
-    'rtp-hdrexts': SmbRtpHeaderExtension[];
-  };
-
-  'video'?: {
-    'streams': SmbVideoStream[];
-    'payload-types': SmbPayloadType[];
-    'rtp-hdrexts'?: SmbRtpHeaderExtension[];
-  };
-
+export interface SmbEndpointDescription extends SfuEndpointDescription {
   'data'?: {
     'port': number;
   };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { WHPPEndpoint, WHEPEndpoint, SfuType } from ".";
 
-const egressStandard = process.env.EGRESS_STANDARD ? process.env.EGRESS_STANDARD : 'whpp';
+const egressStandard = process.env.EGRESS_STANDARD ? process.env.EGRESS_STANDARD : 'whep';
 
 if (egressStandard === 'whep') {
   const endpoint = new WHEPEndpoint({


### PR DESCRIPTION
This PR removes SMB specific types in BaseViewer class. Content still perhaps a bit tied to SMB but this in preparation for generalization and integration with other SFU-types easier.