### PR TITLE
build: generate ts definition files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project ./",
+    "build": "tsc -d --project ./",
     "dev": "tsc-watch --noClear -p ./tsconfig.json --onSuccess \"node --inspect ./dist/server.js\"",
     "server": "node ./dist/server.js",
     "start": "npm run server",


### PR DESCRIPTION
The [current build output](https://www.npmjs.com/package/@eyevinn/wrtc-egress?activeTab=code) doesn't include any typescript definition files (.d.ts)