### PR TITLE
fix: iceServers.urls param can be array of strings

### DIFF
--- a/src/egress/interface.ts
+++ b/src/egress/interface.ts
@@ -1,7 +1,7 @@
 import { SfuType } from "../core/sfu/interface";
 
 export interface ICEServer {
-  urls: string;
+  urls: string | string[];
   username?: string;
   credential?: string;
 }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#iceservers says this for the urls property:

> This required property is either a single string or an array of strings, each specifying a URL which can be used to connect to the server.

I haven't actually looked at how the iceServers interface is used internally but Marcus also thought this would be the correct declaration.